### PR TITLE
Playing a second flowplayer instance stops the first from playing

### DIFF
--- a/flowplayer/scripts/flowplayer.js
+++ b/flowplayer/scripts/flowplayer.js
@@ -42,7 +42,6 @@
                         };
 
                         if (angular.isUndefined(iAttrs.flashConfigKey)) {
-                            console.log('undefined')
                             scope.flashConfigKey = 'default';
                         }
 
@@ -78,6 +77,16 @@
                             });
                         }
 
+                        // Define events for all clips.
+                        angular.extend(flowplayerConfig.clip, {
+                            onFinish: function () {
+                                scope.stop();
+                            },
+                            onStop: function () {
+                                scope.stop();
+                            }
+                        });
+
                         scope.$watch('clip', function (newVal, oldVal) {
                             // Initialise flowplayer.
                             if (angular.isUndefined(player)) {
@@ -97,8 +106,16 @@
                         }, true);
 
                         scope.play = function () {
+                            flowplayer('*').each(function () {
+                                this.stop();
+                            });
                             scope.playing = true;
                             player.play();
+                        };
+
+                        scope.stop = function () {
+                            player.stop();
+                            scope.playing = false;
                         };
                     }
                 }


### PR DESCRIPTION
![flowplayer-posters](https://cloud.githubusercontent.com/assets/1429026/2708261/34f35e3e-c4aa-11e3-8b52-da0854f72dda.gif)

Perhaps a new flowplayer instance must created using the `new` keyword?
https://github.com/incuna/angular-flowplayer/blob/487589b1a969269382a967b2bbc0cb4c7f770c27/flowplayer/scripts/flowplayer.js#L44
